### PR TITLE
Use more than two AZs / VPC subnets / ELBs per ASG

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ Input Variables
    time out. Defaults to 300.
 - `health_check_type` - The health check type. Options are `ELB` and
    `EC2`. It defaults to `ELB` in this module.
-- `load_balancer_name` - The name of the ELB to associate with the ASG,
+- `load_balancer_names` - The name(s) of the ELB(s) to associate with the ASG,
    for settings it's backend instances. Ideally this is a reference to
-   an ELB you're making in the same template as this ASG.
-- `subnet_az1` - The VPC subnet ID for AZ1
-- `subnet_az2` - The VPC subnet ID for AZ2
+   an ELB you're making in the same template as this ASG. Can be a CSV of ELB names 
+   if more than one is desired.
+- `availability_zones` - CSV of availability zones (AZs) for the ASG. *ex. "us-east-1a,us-east-1c"*
+- `vpc_zone_subnets` - CSV of VPC subnets to associate with ASG. There should be one subnet
+   for each of the `availability_zones.` *ex. "subnet-d2gd22,subnet-2kjn8qq"*
 
 Outputs
 -------
@@ -88,8 +90,8 @@ module "my_autoscaling_group" {
   // The health_check_type can be EC2 or ELB and defaults to ELB
   health_check_type = "${var.health_check_type}"
 
-  subnet_az1 = "${var.subnet_az1}"
-  subnet_az2 = "${var.subnet_az2}"
+  availability_zones = "${var.availability_zones}"
+  vpc_zone_subnets = "${var.vpc_zone_subnets}"
 
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"
@@ -112,8 +114,8 @@ module "my_autoscaling_group" {
 - asg_name
 - asg_number_of_instances.
 - load_balancer_name
-- subnet_az1
-- subnet_az2
+- availability_zones
+- vpc_zone_subnets
 
 Authors
 =======

--- a/example/example.tf
+++ b/example/example.tf
@@ -1,0 +1,34 @@
+module "my_autoscaling_group" {
+  
+  source = "../"
+  
+  lc_name = "${var.lc_name}"
+  
+  ami_id = "${var.ami_id}"
+  
+  instance_type = "${var.instance_type}"
+  
+  iam_instance_profile = "${var.iam_instance_profile}"
+  
+  key_name = "${var.key_name}"
+
+  security_group = "${var.security_group_id}"
+
+  user_data = "${var.user_data_file}"
+
+  asg_name = "${var.asg_name}"
+  asg_number_of_instances = "${var.asg_number_of_instances}"
+  asg_minimum_number_of_instances = "${var.asg_minimum_number_of_instances}"
+
+  load_balancer_names = "${var.elb_names}"
+
+  health_check_type = "${var.health_check_type}"
+
+  availability_zones = "${var.availability_zones}"
+  vpc_zone_subnets = "${var.vpc_zone_subnets}"
+
+  aws_access_key = "${var.aws_access_key}"
+  aws_secret_key = "${var.aws_secret_key}"
+  aws_region = "${var.aws_region}"
+
+}

--- a/example/user-data.sh
+++ b/example/user-data.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "hi, mom." > ~/mom.txt

--- a/example/vars.tf
+++ b/example/vars.tf
@@ -1,0 +1,52 @@
+
+variable "lc_name" {
+  default = "example_lc"
+}
+variable "ami_id" {
+  default = "ami-sadfasd"
+}
+variable "instance_type" {
+  default = "m3.medium"
+}
+variable "iam_instance_profile" {
+  default = "test_profile"
+}
+variable "key_name" {
+  default = "my_keypair_name"
+}
+variable "security_group_id" {
+  default = "sg-abcdef"
+}
+variable "user_data_file" {
+  default = "user-data.sh"
+}
+variable "asg_name" {
+  default = "my-custom-asg"
+}
+variable "asg_number_of_instances" {
+  default = 2
+}
+variable "asg_minimum_number_of_instances" {
+  default = 1
+}
+variable "elb_names" {
+  default = "my-elb-name"
+}
+variable "health_check_type" {
+  default = "ELB"
+}
+variable "availability_zones" {
+  default = "us-west-2a,us-west-2b"
+}
+variable "vpc_zone_subnets" {
+  default = "subnet-d2jdfd,subnet-2ell2kd"
+}
+variable "aws_access_key" {
+  default = "SOMEREALACCESSKEY"
+}
+variable "aws_secret_key" {
+  default = "SOMEREALSECRETKEY"
+}
+variable "aws_region" {
+  default = "us-west-2"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,46 +1,49 @@
-//
-// Module: tf_aws_asg_elb
-//
+/*
+ * Module: tf_aws_asg_elb
+ * 
+ * This template creates the following resources
+ *   - A launch configuration
+ *   - A auto-scaling group
+ *   
+ * It requires you create an ELB instance before you use it. 
+ */
 
-// This template creates the following resources
-// - A launch configuration
-// - A auto-scaling group
-// It requires you create an ELB instance before you use it.
-
-// Provider specific configs
+# Provider specific configs
 provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region = "${var.aws_region}"
 }
 
 resource "aws_launch_configuration" "launch_config" {
-    name = "${var.lc_name}"
-    image_id = "${var.ami_id}"
-    instance_type = "${var.instance_type}"
-    iam_instance_profile = "${var.iam_instance_profile}"
-    key_name = "${var.key_name}"
-    security_groups = ["${var.security_group}"]
-    user_data = "${file(var.user_data)}"
+  name = "${var.lc_name}"
+  image_id = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  iam_instance_profile = "${var.iam_instance_profile}"
+  key_name = "${var.key_name}"
+  security_groups = ["${var.security_group}"]
+  user_data = "${file(var.user_data)}"
 }
 
 resource "aws_autoscaling_group" "main_asg" {
-  //We want this to explicitly depend on the launch config above
+  # We want this to explicitly depend on the launch config above
   depends_on = ["aws_launch_configuration.launch_config"]
+  
   name = "${var.asg_name}"
 
-  // The chosen availability zones *must* match the AZs the VPC subnets are
-  //   tied to.
-  availability_zones = ["${var.az1}","${var.az2}"]
-  vpc_zone_identifier = ["${var.subnet_az1}","${var.subnet_az2}"]
+  # The chosen availability zones *must* match the AZs the VPC subnets are tied to.
+  availability_zones = ["${split(",", var.availability_zones)}"]
+  vpc_zone_identifier = ["${split(",", var.vpc_zone_subnets)}"]
 
-  // Uses the ID from the launch config created above
+  # Uses the ID from the launch config created above
   launch_configuration = "${aws_launch_configuration.launch_config.id}"
 
   max_size = "${var.asg_number_of_instances}"
   min_size = "${var.asg_minimum_number_of_instances}"
   desired_capacity = "${var.asg_number_of_instances}"
+  
   health_check_grace_period = "${var.health_check_grace_period}"
   health_check_type = "${var.health_check_type}"
-  load_balancers = ["${var.load_balancer_name}"]
+  
+  load_balancers = ["${split(",", var.load_balancer_names)}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,17 @@
-//
-// Module: tf_aws_asg_elb
-//
+/*
+ * Module: tf_aws_asg_elb
+ *
+ * Outputs:
+ *   - launch_config_id
+ *   - asg_id
+ */
 
-// Output the ID of the Launch Config
+# Output the ID of the Launch Config
 output "launch_config_id" {
     value = "${aws_launch_configuration.launch_config.id}"
 }
 
-// Output the ID of the Launch Config
+# Output the ID of the Launch Config
 output "asg_id" {
     value = "${aws_autoscaling_group.main_asg.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,63 +1,87 @@
-//
-// Module: tf_aws_asg_elb
-//
+/*
+ * Module: tf_aws_asg_elb
+ */
 
-// Module specific variables
-
-// Launch Configuration Variables
-
+#
+# Launch Configuration Variables
+#
 variable "lc_name" {}
-variable "ami_id" {}
+variable "ami_id" {
+  description = "The AMI to use with the launch configuration"
+}
 variable "instance_type" {}
-variable "iam_instance_profile" {}
-variable "key_name" {}
-
-variable "security_group" {}
-
+variable "iam_instance_profile" {
+  description = "The IAM role the launched instance will use"
+}
+variable "key_name" {
+  description = "The SSH public key name (in EC2 key-pairs) to be injected into instances"
+}
+variable "security_group" {
+  description = "ID of SG the launched instance will use"
+}
 variable "user_data" {
   description = "The path to a file with user_data for the instances"
 }
 
-// Auto-Scaling Group
+#
+# Auto-Scaling Group
+#
 variable "asg_name" {}
+
+/* We use this to populate the following ASG settings
+ * - max_size
+ * - desired_capacity
+ */
 variable "asg_number_of_instances" {
   description = "The number of instances we want in the ASG"
-  // We use this to populate the following ASG settings
-  // - max_size
-  // - desired_capacity
 }
 
+/*
+ * Can be set to 0 if you never want the ASG to replace failed instances
+ */
 variable "asg_minimum_number_of_instances" {
   description = "The minimum number of instances the ASG should maintain"
   default = 1
-  // Defaults to 1
-  // Can be set to 0 if you never want the ASG to replace failed instances
 }
-
 variable "health_check_grace_period" {
   description = "Number of seconds for a health check to time out"
   default = 300
 }
+/*
+ * Types available are:
+ *   - ELB
+ *   - EC2
+ *
+ *   @see-also: http://docs.aws.amazon.com/cli/latest/reference/autoscaling/create-auto-scaling-group.html#options
+ */
 variable "health_check_type" {
+  description = "The health check used by the ASG to determine health"
   default = "ELB"
-  //Types available are:
-  // - ELB
-  // - EC2
-  // * http://docs.aws.amazon.com/cli/latest/reference/autoscaling/create-auto-scaling-group.html#options
-}
-variable "load_balancer_name" {}
-
-//Our template assumes two AZs and two VPC subnets for them
-variable "az1" {}
-variable "az2" {}
-variable "subnet_az1" {
-  description = "The VPC subnet ID for AZ1"
-}
-variable "subnet_az2" {
-  description = "The VPC subnet ID for AZ2"
 }
 
-// Variables for providers used in this module
+variable "load_balancer_names" {
+  description = "A comma seperated list string of ELB names the ASG should associate instances with"
+}
+
+/*
+ * A string list of AZs, ex:
+ * "us-east-1a,us-east-1c,us-east-1e"
+ */
+variable "availability_zones" {
+  description = "A comma seperated list string of AZs the ASG will be associated with"
+}
+
+/*
+ * A string list of VPC subnet IDs, ex:
+ * "subnet-d2t4sad,subnet-434ladkn"
+ */
+variable "vpc_zone_subnets" {
+  description = "A comma seperated list string of VPC subnets to associate with ASG, should correspond with var.availability_zones zones"
+}
+
+/*
+ * Variables for providers used in this module
+ */ 
 variable "aws_access_key" {}
 variable "aws_secret_key" {}
 variable "aws_region" {}


### PR DESCRIPTION
- Changed `load_balancer_name` to `load_balancer_names` input can be a CSV
- Changed `az1, az2..` to `availability_zones` input can be a CSV
- Changed `subnet_az1, subnet_az2..` to `vpc_zone_subnets` input can be a CSV
- Added `.editorconfig`
- Tightened up comment formatting
- Added full example
