### PR TITLE
Remove provider stanza so it can be inherited from main.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Input Variables
    `EC2`. It defaults to `ELB` in this module.
 - `load_balancer_names` - The name(s) of the ELB(s) to associate with the ASG,
    for settings it's backend instances. Ideally this is a reference to
-   an ELB you're making in the same template as this ASG. Can be a CSV of ELB names 
+   an ELB you're making in the same template as this ASG. Can be a CSV of ELB names
    if more than one is desired.
 - `availability_zones` - CSV of availability zones (AZs) for the ASG. *ex. "us-east-1a,us-east-1c"*
 - `vpc_zone_subnets` - CSV of VPC subnets to associate with ASG. There should be one subnet
@@ -85,7 +85,7 @@ module "my_autoscaling_group" {
   asg_minimum_number_of_instancs = "${var.asg_minimum_number_of_instances}"
 
   //Using a reference to an SG we create in the same template
-  load_balancer_name = "${module.my_elb.elb_name}"
+  load_balancer_names = "${module.my_elb.elb_name}"
 
   // The health_check_type can be EC2 or ELB and defaults to ELB
   health_check_type = "${var.health_check_type}"
@@ -113,7 +113,7 @@ module "my_autoscaling_group" {
 - user_data
 - asg_name
 - asg_number_of_instances.
-- load_balancer_name
+- load_balancer_names
 - availability_zones
 - vpc_zone_subnets
 

--- a/example/example.tf
+++ b/example/example.tf
@@ -1,15 +1,15 @@
 module "my_autoscaling_group" {
-  
+
   source = "../"
-  
+
   lc_name = "${var.lc_name}"
-  
+
   ami_id = "${var.ami_id}"
-  
+
   instance_type = "${var.instance_type}"
-  
+
   iam_instance_profile = "${var.iam_instance_profile}"
-  
+
   key_name = "${var.key_name}"
 
   security_group = "${var.security_group_id}"
@@ -26,9 +26,4 @@ module "my_autoscaling_group" {
 
   availability_zones = "${var.availability_zones}"
   vpc_zone_subnets = "${var.vpc_zone_subnets}"
-
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
-
 }

--- a/example/vars.tf
+++ b/example/vars.tf
@@ -41,12 +41,3 @@ variable "availability_zones" {
 variable "vpc_zone_subnets" {
   default = "subnet-d2jdfd,subnet-2ell2kd"
 }
-variable "aws_access_key" {
-  default = "SOMEREALACCESSKEY"
-}
-variable "aws_secret_key" {
-  default = "SOMEREALSECRETKEY"
-}
-variable "aws_region" {
-  default = "us-west-2"
-}

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,12 @@
 /*
  * Module: tf_aws_asg_elb
- * 
+ *
  * This template creates the following resources
  *   - A launch configuration
  *   - A auto-scaling group
- *   
- * It requires you create an ELB instance before you use it. 
+ *
+ * It requires you create an ELB instance before you use it.
  */
-
-# Provider specific configs
-provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region = "${var.aws_region}"
-}
 
 resource "aws_launch_configuration" "launch_config" {
   name = "${var.lc_name}"
@@ -28,7 +21,7 @@ resource "aws_launch_configuration" "launch_config" {
 resource "aws_autoscaling_group" "main_asg" {
   # We want this to explicitly depend on the launch config above
   depends_on = ["aws_launch_configuration.launch_config"]
-  
+
   name = "${var.asg_name}"
 
   # The chosen availability zones *must* match the AZs the VPC subnets are tied to.
@@ -41,9 +34,9 @@ resource "aws_autoscaling_group" "main_asg" {
   max_size = "${var.asg_number_of_instances}"
   min_size = "${var.asg_minimum_number_of_instances}"
   desired_capacity = "${var.asg_number_of_instances}"
-  
+
   health_check_grace_period = "${var.health_check_grace_period}"
   health_check_type = "${var.health_check_type}"
-  
+
   load_balancers = ["${split(",", var.load_balancer_names)}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,9 +79,3 @@ variable "vpc_zone_subnets" {
   description = "A comma seperated list string of VPC subnets to associate with ASG, should correspond with var.availability_zones zones"
 }
 
-/*
- * Variables for providers used in this module
- */ 
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}


### PR DESCRIPTION
When running within an ec2 instance the aws keys may be picked up from a IAM role or via the awscli config file so don't force the user to specify these via variables.
