### PR TITLE
propogated ASG tag that affects instances as well

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,12 @@ resource "aws_autoscaling_group" "main_asg" {
 
   name = "${var.asg_name}"
 
+  tag {
+    key = "Name"
+    value= "${var.name}"
+    propagate_at_launch = true
+  }
+
   # The chosen availability zones *must* match the AZs the VPC subnets are tied to.
   availability_zones = ["${split(",", var.availability_zones)}"]
   vpc_zone_identifier = ["${split(",", var.vpc_zone_subnets)}"]


### PR DESCRIPTION
AWS Autoscaling Groups create instances that usually have no tags on them. It is possible to allow "naming" these instances using the "Name" tag that is propagated from the Name tag of the Autoscaling Group.
