### PR TITLE
Allow to use template for user data instead of file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@
  */
 
 resource "aws_launch_configuration" "launch_config" {
+  count = "${var.user_data_file_is_used}"
   name = "${var.lc_name}"
   image_id = "${var.ami_id}"
   instance_type = "${var.instance_type}"
@@ -16,6 +17,17 @@ resource "aws_launch_configuration" "launch_config" {
   key_name = "${var.key_name}"
   security_groups = ["${var.security_group}"]
   user_data = "${file(var.user_data)}"
+}
+
+resource "aws_launch_configuration" "launch_config" {
+  count = "${var.user_data_template_is_used}"
+  name = "${var.lc_name}"
+  image_id = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  iam_instance_profile = "${var.iam_instance_profile}"
+  key_name = "${var.key_name}"
+  security_groups = ["${var.security_group}"]
+  user_data = "${var.user_data_template}"
 }
 
 resource "aws_autoscaling_group" "main_asg" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,8 +19,19 @@ variable "key_name" {
 variable "security_group" {
   description = "ID of SG the launched instance will use"
 }
+variable "user_data_file_is_used" {
+  default = 1
+  description = "Use either a user_data_file, or a user_data_template, not both."
+}
 variable "user_data" {
   description = "The path to a file with user_data for the instances"
+}
+variable "user_data_template_is_used" {
+  default = 0
+  description = "Use either a user_data_template, or a user_data_file, not both."
+}
+variable "user_data_template" {
+  description = "A rendered template with user_data for the instances"
 }
 
 #


### PR DESCRIPTION
The module is forcing to provide a filename in place of the `user_data` variable, while in some instances it is preferable to provide a `template_file.user_data.rendered` instead as value - not as reference.

This change allows to continue using the previous method without change, and for those electing to use as-value there is a flag that enables the new functionality.
